### PR TITLE
Add compile-time binary arithmetic

### DIFF
--- a/Tests/Logic/TestOnePlusOne.cpp
+++ b/Tests/Logic/TestOnePlusOne.cpp
@@ -1,0 +1,5 @@
+#include "../../cpp/Extra/Constexpr/BinaryArithmetic.hpp"
+
+int main() {
+    static_assert(hsd::is_same<hsd::ripple_adder<hsd::natural::one, hsd::natural::one, hsd::bit::zero>, hsd::natural::two>::value);
+}

--- a/cpp/Extra/Constexpr/BinaryArithmetic.hpp
+++ b/cpp/Extra/Constexpr/BinaryArithmetic.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "BooleanLogic.hpp"
+
+namespace hsd {
+    // Complex operations
+    template <Bit S, Bit C>
+    struct sum_carry_pair {
+        using sum = S;
+        using carry = C;
+    };
+
+    template <Bit A, Bit B>
+    using half_adder = sum_carry_pair<op_and<A, B>, op_xor<A, B>>;
+
+    template <Bit A, Bit B, Bit C>
+    struct _full_adder {
+        using partial1 = half_adder<A, B>;
+        using partial2 = half_adder<typename partial1::sum, C>;
+        using partial3 = half_adder<typename partial1::carry, typename partial2::carry>;
+
+        using type = sum_carry_pair<typename partial2::sum, typename partial3::carry>;
+    };
+
+    template <Bit A, Bit B, Bit C>
+    using full_adder = typename _full_adder<A, B, C>::type;
+
+    template <typename F, typename R>
+    struct cons_pair {
+        using first = F;
+        using rest = R;
+    };
+
+    struct nil {};
+
+    template <typename T>
+    struct is_number : false_type {};
+
+    template <Bit F, typename R>
+    struct is_number<cons_pair<F, R>> : is_number<R> {};
+
+    template <>
+    struct is_number<nil> : true_type {};
+
+    template <typename T>
+    concept Number = is_number<T>::value;
+
+    // Gamma operations
+    namespace natural {
+        using zero = nil;
+        using one = cons_pair<bit::one, nil>;
+        using two = cons_pair<bit::zero, cons_pair<bit::one, nil> >;
+        using three = cons_pair<bit::one, cons_pair<bit::one, nil> >;
+        using four = cons_pair<bit::zero, cons_pair<bit::zero, cons_pair<bit::one, nil> > >;
+    }
+
+    template <Number A, Number B, Bit C>
+    struct _ripple_adder {
+        // General case
+        using partial = full_adder<typename A::first, typename B::first, C>;
+
+        using type = cons_pair<typename partial::sum, typename _ripple_adder<typename A::rest, typename B::rest, typename partial::carry>::type>;
+    };
+
+    template <> struct _ripple_adder<nil, nil, bit::zero> { using type = nil; };
+    template <> struct _ripple_adder<nil, nil, bit::one> { using type = cons_pair<bit::one, nil>; };
+
+    template <Bit F, Number R, Bit C>
+    struct _ripple_adder<cons_pair<F, R>, nil, C> {
+        using partial = half_adder<F, C>;
+
+        using type = cons_pair<typename partial::sum, typename _ripple_adder<R, nil, typename partial::carry>::type>;
+    };
+
+    template <Bit F, Number R, Bit C>
+    struct _ripple_adder<nil, cons_pair<F, R>, C> : _ripple_adder<cons_pair<F, R>, nil, C> {};
+
+    template <Number A, Number B, Bit C>
+    using ripple_adder = typename _ripple_adder<A, B, C>::type;
+}

--- a/cpp/Extra/Constexpr/BooleanLogic.hpp
+++ b/cpp/Extra/Constexpr/BooleanLogic.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <type_traits>
+#include "../../TypeTraits.hpp"
+
+namespace hsd {
+    namespace bit {
+        // Basic values
+        struct bitval {};
+        struct zero : bitval {};
+        struct one : bitval {};
+    }
+
+    // Basic traits
+    template <typename T>
+    using is_bit = ::std::is_base_of<bit::bitval, T>;
+
+    template <typename T>
+    concept Bit = is_bit<T>::value;
+
+    template <typename T> struct is_zero;
+    template <> struct is_zero<bit::zero> : true_type {};
+    template <> struct is_zero<bit::one> : false_type {};
+
+    template <typename T> static constexpr inline bool is_zero_v = is_zero<T>::value;
+
+    template <typename T> struct is_one;
+    template <> struct is_one<bit::zero> : false_type {};
+    template <> struct is_one<bit::one> : true_type {};
+
+    template <typename T> static constexpr inline bool is_one_v = is_one<T>::value;
+
+    // Operations
+    template <Bit A, Bit B,
+        Bit V1, Bit V2, Bit V3, Bit V4>
+    struct _binary_operation {
+        using type = conditional_t<
+            is_zero_v<B>,
+            conditional_t<
+                is_zero_v<A>,
+                V1,
+                V2
+            >,
+            conditional_t<
+                is_zero_v<A>,
+                V3,
+                V4
+            >
+        >;
+    };
+
+    template <Bit A, Bit B,
+        Bit V1, Bit V2, Bit V3, Bit V4>
+    using binary_operation = typename _binary_operation<A, B, V1, V2, V3, V4>::type;
+
+    template <Bit A, Bit B>
+    using op_or = binary_operation<A, B, bit::zero, bit::one, bit::one, bit::one>;
+
+    template <Bit A, Bit B>
+    using op_and = binary_operation<A, B, bit::zero, bit::zero, bit::zero, bit::one>;
+
+    template <Bit A, Bit B>
+    using op_xor = binary_operation<A, B, bit::zero, bit::one, bit::one, bit::zero>;
+}

--- a/cpp/TypeTraits.hpp
+++ b/cpp/TypeTraits.hpp
@@ -6,15 +6,15 @@
 
 namespace hsd
 {
-    struct true_type
+    template <typename T, T v>
+    struct literal_constant
     {
-        static constexpr bool value = true;
+        using type = T;
+        static constexpr T value = v;
     };
     
-    struct false_type
-    {
-        static constexpr bool value = false;
-    };
+    using false_type = literal_constant<bool, false>;
+    using true_type = literal_constant<bool, true>;
 
     template<bool, typename>
     struct enable_if

--- a/cpp/Types.hpp
+++ b/cpp/Types.hpp
@@ -7,7 +7,7 @@ namespace hsd
     using usize = unsigned long;
     using isize = long;
 
-    #if defined(HSD_COMPILER_GCC) || defined(HSD_COMPILER_CLANG)
+    #if defined(HSD_COMPILER_GCC) //| defined(HSD_COMPILER_CLANG)
     using u128 = __uint128_t;
     using i128 = __int128_t;
     #endif


### PR DESCRIPTION
Supports compile-time arithmetic on binary values (**using _TYPES ONLY!_**)
Planned features:
- Compile-time conversion (via `consteval`) of binary numeric types to integer constants
- More operations